### PR TITLE
Establish configuration settings for Deviance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,66 @@ The app proper exists at the top level, it includes a few commands for processin
 
 http-server is configured to use port 8069.
 
-## Usage
+## Setup
+
+NightwatchJS will need to be told to load in the command and assertion provided by Deviance.
+To do this add the following lines to your NightwatchJS configuration file(s):
+
+```javascript
+custom_commands_path: [
+    'node_modules/deviance/dist/commands',
+],
+custom_commands_path: [
+    'node_modules/deviance/dist/assertions',
+],
+```
+Note that these properties accept an array and can be used with other commands and assertions. They should sit at the same depth as `src_folders` within the configuration file. You can read more about configuration settings in the [NightwatchJS configuration documentation](http://nightwatchjs.org/gettingstarted#settings-file). 
+
+Deviance will default to the following settings:
+
+```javascript
+const defaultSettings = {
+    reporting: {
+        outputPath: 'tests_output/deviance/report',
+    },
+    regression: {
+        baselinePath: 'tests_output/deviance/regression/baselines',
+        currentPath: 'tests_output/deviance/regression/current',
+    },
+};
+```
+You can modify these settings from within your globals file, as is defined by `globals_path` within your NightwatchJS configuration file.
+
+```javascript
+const Deviance = require('deviance');
+
+/*
+ * Deviance can be constructed with settings to fit your requirements.
+ * You can override just a single settings, some or all of them. 
+ */
+const deviance = new Deviance({
+    reporting: {
+        outputPath: 'your/report/path',
+    },
+    regression: {
+        baselinePath: 'your/regression/baseline/path',
+        currentPath: 'your/regression/baseline/path',
+    },
+});
+
+/*
+ * Then we provide NightwatchJS with the deviance settings as a global property
+ * and define the reporter. You do not have to use the deviance reporter, but the
+ * settings are mandatory for deviance to function
+ */
+module.exports = {
+    deviance: deviance.settings,
+    reporter: deviance.reporter,
+};
+
+```
+
+## Example Usage 
 
 -   Deviance
     -   `yarn build` will compile any changes to the src dir to dist

--- a/example/globals.js
+++ b/example/globals.js
@@ -1,5 +1,16 @@
 const Deviance = require('deviance');
 
+const deviance = new Deviance({
+    reporting: {
+        outputPath: 'output/deviance/report',
+    },
+    regression: {
+        baselinePath: 'output/deviance/regression/baseline',
+        currentPath: 'output/deviance/regression/current',
+    },
+});
+
 module.exports = {
-    reporter: Deviance.reporter,
+    deviance: deviance.settings,
+    reporter: deviance.reporter,
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "e2e-testing"
     ],
     "author": "VictoriaPlum.com",
-    "contributors": [{
+    "contributors": [
+        {
             "name": "David Tolman",
             "email": "david.tolman@victoriaplum.com"
         },
@@ -35,6 +36,7 @@
     },
     "homepage": "https://github.com/VictoriaPlum-com/deviance#readme",
     "dependencies": {
+        "fs-extra": "^7.0.0",
         "handlebars": "^4.0.11",
         "jimp": "^0.2.28",
         "opn": "^5.3.0",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,5 @@
+function hasProperty(object, property) {
+    return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+module.exports = { hasProperty };

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,39 @@
 import htmlReporter from './reporting/html-reporter';
 
+const defaultSettings = {
+    reporting: {
+        outputPath: 'tests_output/deviance/report',
+    },
+    regression: {
+        baselinePath: 'tests_output/deviance/regression/baselines',
+        currentPath: 'tests_output/deviance/regression/current',
+    },
+};
+
+function hasValidSettings(settings) {
+    let isValid = true;
+    Object.values(settings).forEach((value) => {
+        Object.values(value).forEach((setting) => {
+            if (typeof setting !== 'string') {
+                isValid = false;
+            }
+        });
+    });
+
+    return isValid;
+}
+
 module.exports = class Deviance {
-    static reporter(results, done) {
-        htmlReporter.write(results);
+    constructor(settings) {
+        if (!hasValidSettings(settings)) {
+            throw new Error('The Deviance settings provided are invalid');
+        }
+
+        this.settings = Object.assign({}, defaultSettings, settings);
+    }
+
+    reporter(results, done) {
+        htmlReporter.write(results, this.deviance.reporting);
 
         done();
     }

--- a/src/path-generator.js
+++ b/src/path-generator.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+export const types = {
+    baseline: 0,
+    current: 1,
+    diff: 2,
+};
+
+export default function generatorPath(settings, filename, type = types.current) {
+    let basePath;
+    switch (type) {
+    case types.baseline:
+        basePath = settings.baselinePath;
+        break;
+    case types.current:
+        basePath = settings.currentPath;
+        break;
+    case types.diff:
+        basePath = path.join(settings.currentPath, 'diff');
+        break;
+    default:
+        throw new Error('Invalid type provided for visual regression filename');
+    }
+
+    const combinedFilename = `${filename}.png`;
+
+    return path.join(basePath, combinedFilename);
+}
+

--- a/src/reporting/html-reporter.js
+++ b/src/reporting/html-reporter.js
@@ -1,11 +1,12 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const handlebars = require('handlebars');
 const prompt = require('prompt');
 const opn = require('opn');
 
 module.exports = {
-    write: (results) => {
+    write: (results, settings) => {
+        const { outputPath } = settings;
         const templatePath = path.join(__dirname, 'templates', 'html-report.hbs');
 
         fs.readFile(templatePath, (err, data) => {
@@ -13,11 +14,13 @@ module.exports = {
                 throw err;
             }
 
-            const reportPath = path.join(process.cwd(), 'output', `report-${Date.now()}.html`);
+            const reportPath = path.join(process.cwd(), outputPath, `report-${Date.now()}.html`);
             const template = data.toString();
             const content = handlebars.compile(template)({
                 results,
             });
+
+            fs.ensureDirSync(path.dirname(reportPath));
 
             fs.writeFile(reportPath, content, (error) => {
                 if (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,14 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -1337,7 +1345,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1676,6 +1684,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -2647,6 +2661,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 url-regex@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Have decided (by trial and error) the best pattern for settings is for
them to be defined in a NW globals file. This will ensure settings are
available for the assertion, command and reporter and leave the user
having to configure settings in only one location.

Have updated documentation, any changes to configuration values will
have to be updated here too.