### PR TITLE
Scope visual regression under their environments

### DIFF
--- a/example/nightwatch.conf.js
+++ b/example/nightwatch.conf.js
@@ -4,6 +4,7 @@ module.exports = {
     src_folders: 'tests',
     output_folder: 'output',
     globals_path: 'globals.js',
+    live_output: true,
     custom_commands_path: [
         'node_modules/deviance/dist/commands',
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import htmlReporter from './reporting/html-reporter';
 
+const path = require('path');
+
 const defaultSettings = {
     reporting: {
         outputPath: 'tests_output/deviance/report',
@@ -11,12 +13,25 @@ const defaultSettings = {
     },
 };
 
+function getEnvironment() {
+    const envFlags = ['-e', '--env'];
+    const args = process.argv;
+    const index = args.findIndex(arg => envFlags.includes(arg)) + 1;
+
+    return (index > 0 && index < args.length) ? process.argv[index] : 'default';
+}
+
 module.exports = class Deviance {
     constructor(settings) {
         this.settings = {};
         Object.entries(defaultSettings).forEach(([k, v]) => {
             this.settings[k] = Object.assign({}, v, settings[k]);
         });
+
+        const env = getEnvironment();
+        const { expectedPath, actualPath } = this.settings.regression;
+        this.settings.regression.expectedPath = path.join(expectedPath, env);
+        this.settings.regression.actualPath = path.join(actualPath, env);
     }
 
     reporter(results, done) {


### PR DESCRIPTION
This PR adds environment scope to the output paths for the visual regression images, this is critical to the tool working with different environments.