### PR TITLE
Normalise modules

### DIFF
--- a/dist/assertions/elementRegresses.js
+++ b/dist/assertions/elementRegresses.js
@@ -2,14 +2,17 @@
 
 var _helpers = require('../helpers');
 
-exports.assertion = function elementRegression(selector, settings = {}, filename = selector) {
-    this.message = `Deviance regression (pass): <${selector}> comparison passed`;
+exports.assertion = class ElementRegresses {
+    constructor(selector, settings = {}, filename = selector) {
+        this.selector = selector;
+        this.filename = filename;
+        this.message = `Deviance regression (pass): <${selector}> comparison passed`;
+        this.expected = settings.threshold || this.api.globals.deviance.regression.threshold;
+    }
 
-    this.expected = settings.threshold || this.api.globals.deviance.regression.threshold;
-
-    this.pass = data => {
+    pass(data) {
         if (!(0, _helpers.hasProperty)(data, 'expected')) {
-            this.message = `Deviance regression (new): <${selector}> recognised as new regression element`;
+            this.message = `Deviance regression (new): <${this.selector}> recognised as new regression element`;
             return true;
         }
 
@@ -17,24 +20,26 @@ exports.assertion = function elementRegression(selector, settings = {}, filename
         if (expected.width !== actual.width || expected.height !== actual.height) {
             data.message = `${actual.width}x${actual.height}`;
             this.expected = `${expected.width}x${expected.height}`;
-            this.message = `Deviance regression (fail): <${selector}> has changed dimensions`;
+            this.message = `Deviance regression (fail): <${this.selector}> has changed dimensions`;
             return false;
         }
 
         const meetsCriteria = diff.percent < this.expected;
         if (!meetsCriteria) {
-            this.message = `Deviance regression (fail): <${selector}> comparison failed`;
+            this.message = `Deviance regression (fail): <${this.selector}> comparison failed`;
             this.expected = `less than ${this.expected}`;
             data.message = `${diff.percent}`;
         }
 
         return meetsCriteria;
-    };
+    }
 
-    this.value = result => {
+    value(result) {
         result.toString = () => result.message;
         return result;
-    };
+    }
 
-    this.command = callback => this.api.captureElementScreenshot(selector, filename, callback);
+    command(callback) {
+        this.api.captureElementScreenshot(this.selector, this.filename, callback);
+    }
 };

--- a/dist/commands/captureElementScreenshot.js
+++ b/dist/commands/captureElementScreenshot.js
@@ -1,5 +1,15 @@
 'use strict';
 
+var _events = require('events');
+
+var _fsExtra = require('fs-extra');
+
+var _fsExtra2 = _interopRequireDefault(_fsExtra);
+
+var _jimp = require('jimp');
+
+var _jimp2 = _interopRequireDefault(_jimp);
+
 var _pathGenerator = require('../path-generator');
 
 var _pathGenerator2 = _interopRequireDefault(_pathGenerator);
@@ -8,11 +18,7 @@ var _helpers = require('../helpers');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const { EventEmitter } = require('events');
-const Jimp = require('jimp');
-const fs = require('fs-extra');
-
-module.exports = class CaptureElementScreenshot extends EventEmitter {
+module.exports = class CaptureElementScreenshot extends _events.EventEmitter {
     command(selector = 'body', filename = selector, callback = () => {}) {
         const { api } = this.client;
         const { regression: settings } = api.globals.deviance;
@@ -23,15 +29,15 @@ module.exports = class CaptureElementScreenshot extends EventEmitter {
             api.getElementSize(selector, ({ value: { width, height } }) => {
                 api.screenshot(false, screenshotEncoded => {
                     const results = {};
-                    const jimpOperations = [Jimp.read(Buffer.from(screenshotEncoded.value, 'base64'))];
-                    if (fs.existsSync(filenames.expected)) {
-                        jimpOperations.push(Jimp.read(filenames.expected));
+                    const jimpOperations = [_jimp2.default.read(Buffer.from(screenshotEncoded.value, 'base64'))];
+                    if (_fsExtra2.default.existsSync(filenames.expected)) {
+                        jimpOperations.push(_jimp2.default.read(filenames.expected));
                     }
 
                     Promise.all(jimpOperations).then(([actual, expected]) => {
                         if (!(0, _helpers.hasProperty)(settings, 'hasDevianceCaptured')) {
                             settings.hasDevianceCaptured = true;
-                            fs.emptyDirSync(settings.actualPath);
+                            _fsExtra2.default.emptyDirSync(settings.actualPath);
                         }
 
                         actual.crop(x, y, width, height).quality(100).write(filenames.actual);
@@ -48,7 +54,7 @@ module.exports = class CaptureElementScreenshot extends EventEmitter {
                                 height: expected.bitmap.height
                             };
 
-                            const diff = Jimp.diff(actual, expected);
+                            const diff = _jimp2.default.diff(actual, expected);
                             results.diff = {
                                 path: filenames.diff,
                                 percent: diff.percent

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,7 +1,10 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
 function hasProperty(object, property) {
     return Object.prototype.hasOwnProperty.call(object, property);
 }
 
-module.exports = { hasProperty };
+exports.hasProperty = hasProperty;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
 var _reporter = require('./reporting/reporter');
 
 var _reporter2 = _interopRequireDefault(_reporter);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-const path = require('path');
 
 const defaultSettings = {
     reporting: {
@@ -37,8 +39,8 @@ module.exports = class Deviance {
 
         const env = getEnvironment();
         const { expectedPath, actualPath } = this.settings.regression;
-        this.settings.regression.expectedPath = path.join(expectedPath, env);
-        this.settings.regression.actualPath = path.join(actualPath, env);
+        this.settings.regression.expectedPath = _path2.default.join(expectedPath, env);
+        this.settings.regression.actualPath = _path2.default.join(actualPath, env);
     }
 
     reporter(results, done) {

--- a/dist/path-generator.js
+++ b/dist/path-generator.js
@@ -4,15 +4,20 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 exports.default = generatePaths;
-const path = require('path');
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function generatePaths(settings, filename, testName, testModule) {
     const name = testName.replace(/[^a-z0-9]/gi, '-');
     const file = `${filename.replace(/[^a-z0-9]/gi, '-')}.png`;
 
     return {
-        expected: path.join(settings.expectedPath, testModule, name, file),
-        actual: path.join(settings.actualPath, testModule, name, file),
-        diff: path.join(settings.actualPath, testModule, name, 'diff', file)
+        expected: _path2.default.join(settings.expectedPath, testModule, name, file),
+        actual: _path2.default.join(settings.actualPath, testModule, name, file),
+        diff: _path2.default.join(settings.actualPath, testModule, name, 'diff', file)
     };
 }

--- a/dist/reporting/reporter.js
+++ b/dist/reporting/reporter.js
@@ -1,5 +1,9 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
 var _prompt = require('prompt/lib/prompt');
 
 var _prompt2 = _interopRequireDefault(_prompt);
@@ -14,7 +18,7 @@ var _resultsFormatter2 = _interopRequireDefault(_resultsFormatter);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = {
+exports.default = {
     write: (results, settings) => {
         _prompt2.default.start({ noHandleSIGINT: true });
 
@@ -28,7 +32,6 @@ module.exports = {
             }
         };
 
-        console.log("prepromt");
         _prompt2.default.get(schema, (errors, { report }) => {
             if (errors) {
                 throw errors;

--- a/dist/reporting/server.js
+++ b/dist/reporting/server.js
@@ -5,6 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = serve;
 
+var _bodyParser = require('body-parser');
+
+var _bodyParser2 = _interopRequireDefault(_bodyParser);
+
 var _express = require('express');
 
 var _express2 = _interopRequireDefault(_express);
@@ -16,10 +20,6 @@ var _expressHandlebars2 = _interopRequireDefault(_expressHandlebars);
 var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
-
-var _bodyParser = require('body-parser');
-
-var _bodyParser2 = _interopRequireDefault(_bodyParser);
 
 var _regressionApprover = require('./regression-approver');
 

--- a/src/assertions/elementRegresses.js
+++ b/src/assertions/elementRegresses.js
@@ -1,13 +1,20 @@
 import { hasProperty } from '../helpers';
 
-exports.assertion = function elementRegression(selector, settings = {}, filename = selector) {
-    this.message = `Deviance regression (pass): <${selector}> comparison passed`;
+exports.assertion = class ElementRegresses {
+    constructor(selector, settings = {}, filename = selector) {
+        this.selector = selector;
+        this.filename = filename;
+        this.message = `Deviance regression (pass): <${selector}> comparison passed`;
+        this.expected = settings.threshold || this.api.globals.deviance.regression.threshold;
+        this.value = (result) => {
+            result.toString = () => result.message;
+            return result;
+        };
+    }
 
-    this.expected = settings.threshold || this.api.globals.deviance.regression.threshold;
-
-    this.pass = (data) => {
+    pass(data) {
         if (!hasProperty(data, 'expected')) {
-            this.message = `Deviance regression (new): <${selector}> recognised as new regression element`;
+            this.message = `Deviance regression (new): <${this.selector}> recognised as new regression element`;
             return true;
         }
 
@@ -15,24 +22,21 @@ exports.assertion = function elementRegression(selector, settings = {}, filename
         if (expected.width !== actual.width || expected.height !== actual.height) {
             data.message = `${actual.width}x${actual.height}`;
             this.expected = `${expected.width}x${expected.height}`;
-            this.message = `Deviance regression (fail): <${selector}> has changed dimensions`;
+            this.message = `Deviance regression (fail): <${this.selector}> has changed dimensions`;
             return false;
         }
 
         const meetsCriteria = diff.percent < this.expected;
         if (!meetsCriteria) {
-            this.message = `Deviance regression (fail): <${selector}> comparison failed`;
+            this.message = `Deviance regression (fail): <${this.selector}> comparison failed`;
             this.expected = `less than ${this.expected}`;
             data.message = `${diff.percent}`;
         }
 
         return meetsCriteria;
-    };
+    }
 
-    this.value = (result) => {
-        result.toString = () => result.message;
-        return result;
-    };
-
-    this.command = callback => this.api.captureElementScreenshot(selector, filename, callback);
+    command(callback) {
+        this.api.captureElementScreenshot(this.selector, this.filename, callback);
+    }
 };

--- a/src/commands/captureElementScreenshot.js
+++ b/src/commands/captureElementScreenshot.js
@@ -1,9 +1,8 @@
+import { EventEmitter } from 'events';
+import fs from 'fs-extra';
+import Jimp from 'jimp';
 import generatePaths from '../path-generator';
 import { hasProperty } from '../helpers';
-
-const { EventEmitter } = require('events');
-const Jimp = require('jimp');
-const fs = require('fs-extra');
 
 module.exports = class CaptureElementScreenshot extends EventEmitter {
     command(selector = 'body', filename = selector, callback = () => {}) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,4 +2,4 @@ function hasProperty(object, property) {
     return Object.prototype.hasOwnProperty.call(object, property);
 }
 
-module.exports = { hasProperty };
+export { hasProperty };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
+import path from 'path';
 import reporter from './reporting/reporter';
-
-const path = require('path');
 
 const defaultSettings = {
     reporting: {

--- a/src/path-generator.js
+++ b/src/path-generator.js
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'path';
 
 export default function generatePaths(settings, filename, testName, testModule) {
     const name = testName.replace(/[^a-z0-9]/gi, '-');

--- a/src/reporting/reporter.js
+++ b/src/reporting/reporter.js
@@ -2,7 +2,7 @@ import prompt from 'prompt/lib/prompt';
 import serve from './server';
 import ResultsFormatter from './results-formatter';
 
-module.exports = {
+export default {
     write: (results, settings) => {
         prompt.start({ noHandleSIGINT: true });
 

--- a/src/reporting/server.js
+++ b/src/reporting/server.js
@@ -1,7 +1,7 @@
+import bodyParser from 'body-parser';
 import express from 'express';
 import exphbs from 'express-handlebars';
 import path from 'path';
-import bodyParser from 'body-parser';
 import approve from './regression-approver';
 
 export default function serve(port, results, settings) {


### PR DESCRIPTION
Standardise module import and export syntax. Left `module.exports` in place for index.js and command and assertions so Nightwatch will play nicely.