### PR TITLE
fix: object property changes required on regression approver

### DIFF
--- a/dist/reporting/regression-approver.js
+++ b/dist/reporting/regression-approver.js
@@ -16,20 +16,20 @@ var _path2 = _interopRequireDefault(_path);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function approve(assertion) {
-    const { expected, actual, diff } = assertion.filePath;
+    const { expected, actual, diff } = assertion.devianceFilePath;
 
-    if (!assertion.isNew) {
+    if (!assertion.isNewDeviance) {
         _fsExtra2.default.unlinkSync(diff);
         _fsExtra2.default.unlinkSync(expected);
-        assertion.filePath.diff = null;
+        assertion.devianceFilePath.diff = null;
     }
 
     _fsExtra2.default.ensureDirSync(_path2.default.dirname(expected));
     _fsExtra2.default.renameSync(actual, expected);
 
-    assertion.filePath.actual = null;
+    assertion.devianceFilePath.actual = null;
     assertion.failure = false;
-    assertion.isNew = false;
+    assertion.isNewDeviance = false;
 
     assertion.message = assertion.message.replace('(fail)', '(approved)');
     assertion.message = assertion.message.replace('(new)', '(approved)');

--- a/dist/reporting/views/index.handlebars
+++ b/dist/reporting/views/index.handlebars
@@ -154,7 +154,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="column column-33 column-offset-66" style="text-align:center">
-                                            <button class="i-approve" data-id="{{ id }}">Approve change</button>
+                                            <button class="i-approve" data-id="{{ devianceId }}">Approve change</button>
                                         </div>
                                     </div>
                                 {{/if}}

--- a/src/reporting/regression-approver.js
+++ b/src/reporting/regression-approver.js
@@ -2,20 +2,20 @@ import fs from 'fs-extra';
 import path from 'path';
 
 export default function approve(assertion) {
-    const { expected, actual, diff } = assertion.filePath;
+    const { expected, actual, diff } = assertion.devianceFilePath;
 
-    if (!assertion.isNew) {
+    if (!assertion.isNewDeviance) {
         fs.unlinkSync(diff);
         fs.unlinkSync(expected);
-        assertion.filePath.diff = null;
+        assertion.devianceFilePath.diff = null;
     }
 
     fs.ensureDirSync(path.dirname(expected));
     fs.renameSync(actual, expected);
 
-    assertion.filePath.actual = null;
+    assertion.devianceFilePath.actual = null;
     assertion.failure = false;
-    assertion.isNew = false;
+    assertion.isNewDeviance = false;
 
     assertion.message = assertion.message.replace('(fail)', '(approved)');
     assertion.message = assertion.message.replace('(new)', '(approved)');

--- a/src/reporting/views/index.handlebars
+++ b/src/reporting/views/index.handlebars
@@ -154,7 +154,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="column column-33 column-offset-66" style="text-align:center">
-                                            <button class="i-approve" data-id="{{ id }}">Approve change</button>
+                                            <button class="i-approve" data-id="{{ devianceId }}">Approve change</button>
                                         </div>
                                     </div>
                                 {{/if}}

--- a/test/reporting/regression-approver.test.js
+++ b/test/reporting/regression-approver.test.js
@@ -8,12 +8,12 @@ let mockData;
 describe('Given approve', () => {
     beforeAll(() => {
         mockData = {
-            filePath: {
+            devianceFilePath: {
                 expected: 'mock/expected/file/path/img.png',
                 actual: 'mock/actual/file/path/img.png',
                 diff: 'mock/diff/file/path/img.png',
             },
-            isNew: false,
+            isNewDeviance: false,
             failure: null,
             message: 'mock message (fail)',
         };
@@ -36,8 +36,8 @@ describe('Given approve', () => {
             expect(fs.unlinkSync).toHaveBeenCalledWith('mock/expected/file/path/img.png');
         });
 
-        it('Then sets diff filePath to null', () => {
-            expect(mockData.filePath.diff).toBeNull();
+        it('Then sets diff devianceFilePath to null', () => {
+            expect(mockData.devianceFilePath.diff).toBeNull();
         });
     });
 
@@ -58,8 +58,8 @@ describe('Given approve', () => {
             expect(fs.renameSync).toBeCalledWith('mock/actual/file/path/img.png', 'mock/expected/file/path/img.png');
         });
 
-        it('Then sets actual filePath to null', () => {
-            expect(mockData.filePath.actual).toBeNull();
+        it('Then sets actual devianceFilePath to null', () => {
+            expect(mockData.devianceFilePath.actual).toBeNull();
         });
 
         it('Then failure is set to false ', () => {
@@ -75,12 +75,12 @@ describe('Given approve', () => {
 describe('Given approve using a new image to approve', () => {
     beforeAll(() => {
         mockData = {
-            filePath: {
+            devianceFilePath: {
                 expected: '',
                 actual: 'mock/actual/file/path/img.png',
                 diff: '',
             },
-            isNew: true,
+            isNewDeviance: true,
             failure: null,
             message: 'mock message (new)',
         };
@@ -96,8 +96,8 @@ describe('Given approve using a new image to approve', () => {
             expect(fs.unlinkSync).not.toHaveBeenCalled();
         });
 
-        it('Then isNew should be set to false', () => {
-            expect(mockData.isNew).toBe(false);
+        it('Then isNewDeviance should be set to false', () => {
+            expect(mockData.isNewDeviance).toBe(false);
         });
 
         it('Then message text "(new)" is replaced with "(approved)"', () => {


### PR DESCRIPTION
Some properties were changes for clarity around if a failure was related to nightwatch or deviance. The regression approver file was missed when making the changes which prevented users from being able to approve visual regressions.