### PR TITLE
fix: change how report server is terminated

### DIFF
--- a/dist/reporting/server.js
+++ b/dist/reporting/server.js
@@ -31,9 +31,23 @@ var _regressionApprover2 = _interopRequireDefault(_regressionApprover);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+let server;
+let closer;
+
+function setCloser(timeout = 4000) {
+    if (closer) {
+        clearTimeout(closer);
+    }
+
+    closer = setTimeout(() => {
+        server.close();
+        console.log('Report closed');
+        process.exit();
+    }, timeout);
+}
+
 function serve(port, results, settings) {
     const app = (0, _express2.default)();
-    let server;
 
     app.engine('handlebars', (0, _expressHandlebars2.default)());
 
@@ -46,11 +60,10 @@ function serve(port, results, settings) {
         res.render('index', { results });
     });
 
-    app.post('/terminate', (req, res) => {
-        res.send('Going away....');
-        server.close();
-        console.log('Report closed');
-        process.exit();
+    setCloser();
+    app.post('/keep-alive', (req, res) => {
+        setCloser();
+        res.send('OK');
     });
 
     app.post('/approve', (req, res) => {

--- a/dist/reporting/views/index.handlebars
+++ b/dist/reporting/views/index.handlebars
@@ -309,17 +309,16 @@
             });
         });
 
-        function terminateServer() {
-            fetch('/terminate', {
+        function keepServerAlive() {
+            fetch('/keep-alive', {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json; charset=utf-8",
                 },
-                body: JSON.stringify({}),
             });
         }
 
-        window.addEventListener('unload', terminateServer);
+        setInterval(() => keepServerAlive(), 1000);
 
         [...document.querySelectorAll('img')].forEach((img) => {
             new Viewer(img);

--- a/src/reporting/views/index.handlebars
+++ b/src/reporting/views/index.handlebars
@@ -309,17 +309,16 @@
             });
         });
 
-        function terminateServer() {
-            fetch('/terminate', {
+        function keepServerAlive() {
+            fetch('/keep-alive', {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json; charset=utf-8",
                 },
-                body: JSON.stringify({}),
             });
         }
 
-        window.addEventListener('unload', terminateServer);
+        setInterval(() => keepServerAlive(), 1000);
 
         [...document.querySelectorAll('img')].forEach((img) => {
             new Viewer(img);


### PR DESCRIPTION
This should allow page refreshes and a small window during which the report can be navigated away from and back to (say viewing an image via contextmenu in Firefox)