### PR TITLE
fix: node env vars are strings, reportEnabled needs to take this into…

### DIFF
--- a/src/reporting/reporter.js
+++ b/src/reporting/reporter.js
@@ -6,7 +6,7 @@ export default {
     write: (results, settings) => {
         let reportEnabled = settings.reporting.enabled;
         if (hasProperty(process.env, 'OPEN_REPORT')) {
-            reportEnabled = process.env.OPEN_REPORT;
+            reportEnabled = process.env.OPEN_REPORT === 'true';
         }
 
         if (reportEnabled) {


### PR DESCRIPTION
Node env `OPEN_REPORT=false` will actually be truthy, it gets passed as a string.